### PR TITLE
Faster completion and list source in answer

### DIFF
--- a/packages/ml/src/agent.py
+++ b/packages/ml/src/agent.py
@@ -209,6 +209,7 @@ class Agent(BaseModel):
             # ReAct: Reasoning
             await self.ui.notify(stream=True, title="", message="Thinking...")
             should_try_complete = False
+            should_summary = True
             keep_it = True
             tool_name = None
             while keep_it:
@@ -217,7 +218,7 @@ class Agent(BaseModel):
                 try:
                     reasoning_result = await self._reason(
                         should_try_complete=should_try_complete,
-                        should_summary=should_try_complete
+                        should_summary=should_summary
                     )  # type: ignore
                     thoughts = reasoning_result["thoughts"]  # type: ignore
                     action = reasoning_result["action"]  # type: ignore
@@ -351,6 +352,7 @@ class Agent(BaseModel):
                     raise e
 
             episode = Episode(
+                question=self.question, task=self.task_manager.get_current_task_string(), 
                 thoughts=thoughts, action=action, result=action_result
             )  # type: ignore
 
@@ -397,8 +399,8 @@ class Agent(BaseModel):
             "question": self.question,
             "completed_tasks": self.task_manager.get_completed_tasks_as_string(),
             "results_of_completed_tasks": self.task_manager.get_results_completed_tasks_as_string(),
-            "related_knowledge": all_related_knowledge,
-            "related_past_episodes": all_related_past_episodes,
+            # "related_knowledge": all_related_knowledge,
+            # "related_past_episodes": all_related_past_episodes,
             "next_possible_tasks": self.task_manager.get_incomplete_tasks_string(),
         }
 

--- a/packages/ml/src/llm/extract_entity/prompt.py
+++ b/packages/ml/src/llm/extract_entity/prompt.py
@@ -10,9 +10,10 @@ from langchain.prompts.chat import (
 JSON_SCHEMA_STR = json.dumps(JsonSchema.schema)
 
 ENTITY_EXTRACTION_TEMPLATE = """
-You are an AI assistant for extracting entities from a text [INPUT TEXT].
+You are an AI assistant for extracting relevant factual information from a text [INPUT TEXT].
 You are extracting information to complete task [TASK] in order to answer the question [QUESTION]. 
-Extract ONLY proper nouns from [INPUT TEXT] that help complete the task [TASK] and return them as a JSON object following [JSON RESPONSE FORMAT]. 
+Extract ONLY proper nouns from [INPUT TEXT] that help complete the task [TASK] and return them as a JSON object following [JSON RESPONSE FORMAT].
+Only extract information from [INPUT TEXT] and do not make up any false information.
 
 [QUESTION]:
 {question}

--- a/packages/ml/src/llm/generate_task_plan/prompt.py
+++ b/packages/ml/src/llm/generate_task_plan/prompt.py
@@ -38,28 +38,29 @@ Subquestions should help you break down the main question into smaller, more man
 BASE_TEMPLATE = """
 You are {name}, {role}
 
-You should create one or several new tasks that can help answer the main question [QUESTION]. 
+Create one or several new tasks that can help answer the main question [QUESTION] while following the rules in [RULES].
+The tasks should be focussed on extracting specific information from text in order to answer [QUESTION]
 
 [QUESTION]
 {question}
 
-[YOUR MISSION]
-Based on the [QUESTION], create tasks following these rules: 
-- Tasks should be defined to lead to a final answer to [QUESTION] and can be the same as [QUESTION].
-- Tasks should be ordered so that tasks that depend on the output of other tasks are only listed later. 
-- Tasks should specify what information needs to be collected, not how it needs to be done.
-
 [RESPONSE FORMAT]
 Return the tasks as a list of strings.
-- Max 3 best tasks but ideally only 1 task. 
-- Define tasks in a way that requires solving as little tasks as possible in order to find a final answer to [QUESTION].
+- Define a maximum of 3 tasks but ideally only 1 task.
 - Enclose each task in double quotation marks.
 - Separate tasks with Tabs.
 - Use [] only at the beginning and end.
 
 ["Task 1 that the AI assistant should perform"\t"Task 2 that the AI assistant should perform",\t ...]
 
-Now, based on the main question [QUESTION], generate the tasks that should be completed to answer the main question.
+[RULES]
+Based on the [QUESTION], create tasks following these rules: 
+- Only create tasks that clearly define when the task is considered complete. 
+- Tasks should be defined to lead to an answer to [QUESTION] as fast as possible.
+- Tasks may be the same as [QUESTION].
+- If there are multiple tasks then they should be ordered so that tasks that depend on the output of other tasks are only listed later. 
+
+Based on the main question [QUESTION] and the rules in [RULES], generate the tasks that should be completed to answer the main question.
 
 [RESPONSE]
 """

--- a/packages/ml/src/llm/reason/prompt.py
+++ b/packages/ml/src/llm/reason/prompt.py
@@ -19,10 +19,10 @@ JSON_SCHEMA_STR = json.dumps(JsonSchema.schema)
 BASE_TEMPLATE = """
 You are {name}, {role}
 
-You should complete the task defined in [YOUR TASK] in order to find an answer to the question in [QUESTION]. 
+You should complete the task defined in [TASK] in order to find an answer to the question in [QUESTION]. 
 Your decisions must always be made independently without seeking user assistance or asking for anyone to help. 
-Pursue simple strategies to complete your task. 
-Use ONLY your [TOOLS] available as well as [RELATED KNOWLEDGE] and [RELATED PAST EPISODES] to complete your task.
+Base your actions on the information in [RELATED KNOWLEDGE] and [RELATED PAST EPISODES]. 
+Use ONLY your [TOOLS] available to complete your task.
 
 [QUESTION]
 {question}
@@ -41,18 +41,18 @@ This reminds you of related knowledge:
 This reminds you of related past events:
 {related_past_episodes}
 
-[YOUR TASK]
+[TASK]
 You are given the following task:
 {task}
 
 [TOOLS USAGE]
 You can ONLY USE ONE TOOL at a time and only use tools that are listed below. 
-Remember to use the task_complete tool to mark the task as done.
+Remember to use the task_complete tool to mark the task as done when you have completed [TASK] or know the answer to [QUESTION].
 Format below:
 tool name: "tool description", arg1: <arg1>, arg2: <arg2>
 
 [TOOLS]
-task_complete: "If you found the answer to complete the task, please use this tool to mark it as done and include your answer to the task in the 'args' field.", result: <Answer to the assigned task>
+task_complete: "Use this tool to mark the task as done and include your answer to the task in the 'args' field. If possible, include the date, channel and author in your answer. Certainly use this tool when you know the answer to [QUESTION] or completed the [TASK].", result: <Answer to the assigned task>
 {tool_info}
 """
 
@@ -77,8 +77,8 @@ Please ensure your output strictly follows [JSON RESPONSE FORMAT].
 [JSON RESPONSE FORMAT]
 {JSON_SCHEMA_STR}
 
-Determine which next [TOOL] to use, check in [RECENT EPISODES] or [RELATED PAST EPISODES] messages if you already performed the same action with the same args for the task and avoid doing it again to prevent an infinite loop. 
-If the task in [TASK] can be completed with the information in [RELATED KNOWLEDGE] or [RELATED PAST EPISODES], always choose to use the task_complete tool.
+Determine which next [TOOL] to use. 
+If the question in [QUESTION] can be answered or the task in [TASK] can be completed with the information in [RELATED KNOWLEDGE] or [RELATED PAST EPISODES], always choose to use the task_complete tool.
 Respond using the format specified in [JSON RESPONSE FORMAT]:
 """.replace(
     "{", "{{"

--- a/packages/ml/src/llm/reason/schema.py
+++ b/packages/ml/src/llm/reason/schema.py
@@ -1,19 +1,19 @@
 class JsonSchema:
     schema = {
-        "observation": "observation of [RECENT EPISODES]",
+        "observation": "Observation of [RELATED PAST EPISODES]",
         "thoughts": {
-            "task": "description of [YOUR TASK] assigned to you",
-            "knowledge": "if there is any helpful knowledge in [RELATED KNOWLEDGE] for the task, summarize the key points here",
-            "past_events": "if there is any helpful past events in [RELATED PAST EPISODES] for the task, summarize the key points here",
+            "task": "Description of the [QUESTION] and the related [TASK] assigned to you",
+            "knowledge": "If there is any helpful information related to task in [RELATED KNOWLEDGE], summarize the key points here in one sentence. Otherwise respond 'N/A'",
+            "past_events": "If there is any helpful information reated to task in [RELATED PAST EPISODES], summarize the key points here. Otherwise respond 'N/A'",
             # "past_tool_used": "observe in [RELATED PAST EPISODES] what tools with args were already used to avoid re-use them in action",
-            "idea": "thought to complete the task based on available knowledge",
-            "reasoning": "reasoning of the thought",
-            "criticism": "constructive self-criticism",
+            "reasoning": "Reasoning about the action to complete the task based on information in knowledge and past_events and using one of the tools in [TOOLS]. If the task can be completed, always use the task_complete tool.",
+            "idea": "Idea for an action using one of the tools in [TOOLS] to complete the task based on information in knowledge and past_events. If the task can be completed, always use the task_complete tool.",
+            "criticism": "If the task can be completed based on the information in knowledge and past_events, say 'The task_complete tool must be used. This decision overrides reasoning and idea' ",
             # "criticism": "constructive self-criticism towards to complete the task",
-            "summary": "thoughts summary to say to user, don't mention any tools",
+            "summary": "Summary of the reasoning, action idea and criticism for the task based on knowledge and past_events",
         },
         "action": {
-            "tool_name": "Only one of the tool names included in [TOOLS] section. Avoid using tools that do not exist in the [TOOLS] section. If the task in [TASK] can be completed with the information in [RELATED KNOWLEDGE] or [RELATED PAST EPISODES], always choose to use the task_complete tool.",
+            "tool_name": "Only one of the tool names included in [TOOLS] section. Never come up with tools that do not exist in the [TOOLS] section. If the task in [TASK] can be completed with the information in [RELATED KNOWLEDGE] or [RELATED PAST EPISODES], always choose to use the task_complete tool and provide the date, channel and author in your answer.",
             "args": {"arg name": "value", "arg name": "value"},
         },
     }

--- a/packages/ml/src/llm/summarize/prompt.py
+++ b/packages/ml/src/llm/summarize/prompt.py
@@ -2,6 +2,12 @@ from langchain.prompts import PromptTemplate
 
 # Convert the schema object to a string
 BASE_TEMPLATE = """
+[QUESTION]
+{question}
+
+[TASK]
+{task}
+
 [THOUGHTS]
 {thoughts}
 
@@ -12,7 +18,9 @@ BASE_TEMPLATE = """
 {result}
 
 [INSTRUCTION]
-Using above [THOUGHTS], [ACTION], and [RESULT OF ACTION], please summarize the event.
+Using only [THOUGHTS], [ACTION], and [RESULT OF ACTION] above, please summarize the event.
+Only summarize information that is relevant to answering [QUESTION] or completing [TASK].
+Include the date, channel and author for the message with the relevant information. Don't include which tool was used.
 
 [SUMMARY]
 """
@@ -35,18 +43,11 @@ You have completed all tasks to get to the answer. Now you need to find a final 
 [NEXT POSSIBLE TASKS]
 {next_possible_tasks}
 
-[RELATED KNOWLEDGE] 
-This reminds you of related knowledge:
-{related_knowledge}
-
-[RELATED PAST EPISODES]
-This reminds you of related past events summarized:
-{related_past_episodes}
-
 [INSTRUCTION]
- - Using above [RESULTS OF COMPLETED TASKS], [RELATED KNOWLEDGE], and [RELATED PAST EPISODES], answer the [QUESTION].
+ - Using only the information in [RESULTS OF COMPLETED TASKS] answer the [QUESTION].
+ - If possible, include the date, channel and/or author in your answer.
  - If you are not able to fully answer the question and you think that performing [NEXT POSSIBLE TASKS] will lead to a better answer, answer "continue"
- - If it's not possible to find the answer, answer "I don't know"
+ - If it's not possible to find the answer, answer "I don't know" and say why you can't find the answer. If relevant, say what additional information is needed to answer the question.
 
 [FINAL ANSWER]
 """
@@ -55,7 +56,7 @@ This reminds you of related past events summarized:
 def get_template() -> PromptTemplate:
     template = BASE_TEMPLATE
     prompt_template = PromptTemplate(
-        input_variables=["thoughts", "action", "result"], template=template
+        input_variables=["question" , "task", "thoughts", "action", "result"], template=template
     )
     return prompt_template
 
@@ -70,8 +71,8 @@ def get_final_answer_template() -> PromptTemplate:
             "question",
             "completed_tasks",
             "results_of_completed_tasks",
-            "related_knowledge",
-            "related_past_episodes",
+            # "related_knowledge",
+            # "related_past_episodes",
             "next_possible_tasks",
         ],
         template=template,

--- a/packages/ml/src/memory/episodic_memory.py
+++ b/packages/ml/src/memory/episodic_memory.py
@@ -13,6 +13,8 @@ class Episode(BaseModel):
     action: Dict[str, Any] = Field(..., description="action of the agent")
     result: str = Field(..., description="The plan of the event")
     summary: str = Field("", description="summary of the event")
+    question: str = Field("", description="question to be answered")
+    task: str = Field("", description="task to be completed")
 
     # create like equals method to compare two episodes
     def __eq__(self, other):
@@ -51,21 +53,21 @@ class EpisodicMemory(BaseModel):
     async def summarize_and_memorize_episode(self, episode: Episode) -> str:
         """Summarize and memorize an episode."""
         summary = await self._summarize(
-            episode.thoughts, episode.action, episode.result
+            episode.question, episode.task, episode.thoughts, episode.action, episode.result
         )
         episode.summary = summary
         self.memorize_episode(episode)
         return summary
 
     async def _summarize(
-        self, thoughts: Dict[str, Any], action: Dict[str, Any], result: str
+        self, question: str, task: str, thoughts: Dict[str, Any], action: Dict[str, Any], result: str
     ) -> str:
         """Summarize an episode."""
         prompt = get_template()
         llm_chain = LLMChain(prompt=prompt, llm=self.llm)
         try:
             result = await llm_chain.apredict(
-                thoughts=thoughts, action=action, result=result
+                question=question, task=task, thoughts=thoughts, action=action, result=result
             )
         except Exception as e:
             raise Exception(f"Error: {e}")


### PR DESCRIPTION
I made the following main changes:
- Episode summaries are used only
- When making episode summaries, only information relevant to question and/or task is stored
- The date, channel and author of the message that leads to the answer is included in the final answer
- I added a lot of small changes aimed at making the system choose to give the final answer
